### PR TITLE
Misc fixes - dataset generation and episode sampling logic, training code, mps device option for mac

### DIFF
--- a/external_rl/utils/other.py
+++ b/external_rl/utils/other.py
@@ -4,7 +4,11 @@ import torch
 import collections
 
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+device = torch.device(
+    "cuda"
+    if torch.cuda.is_available()
+    else ("mps" if torch.backends.mps.is_available() else "cpu")
+)
 
 
 def seed(seed):

--- a/src/agent/agent.py
+++ b/src/agent/agent.py
@@ -53,4 +53,7 @@ class RandomAgent(Agent):
         return torch.tensor(0.0, requires_grad=True)
 
     def get_action(self, input: AgentInput, context=1, one_hot=False):
-        return torch.tensor(np.random.random(self.act_dim), device=input.states.device)
+        return torch.tensor(
+            np.random.random(self.act_dim).astype(np.float32),
+            device=input.states.device,
+        )

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,3 +1,5 @@
 import os
 
 FEEDBACK_DIR = f"{os.path.abspath('')}/feedback_data"
+ENV_METADATA_PATH = f"{os.path.abspath('')}/env_metadata.jsonc"
+OUTPUT_PATH = f"{os.path.abspath('')}/data/output"

--- a/src/dataset/custom_dataset.py
+++ b/src/dataset/custom_dataset.py
@@ -456,7 +456,7 @@ class CustomDataset:
         start = self.episode_starts[ep_idx]
         if random_start:
             start += np.random.randint(
-                0, self.episode_lengths[ep_idx] - self.episode_lengths[ep_idx] // 4
+                0, self.episode_lengths[ep_idx] - self.episode_lengths[ep_idx] // 2
             )
         tmp = start + length if length else self.episode_ends[ep_idx]
         end = min(tmp, self.episode_ends[ep_idx])

--- a/src/dataset/custom_dataset.py
+++ b/src/dataset/custom_dataset.py
@@ -456,7 +456,9 @@ class CustomDataset:
         start = self.episode_starts[ep_idx]
         if random_start:
             start += np.random.randint(
-                0, self.episode_lengths[ep_idx] - self.episode_lengths[ep_idx] // 2
+                0,
+                self.episode_lengths[ep_idx]
+                - max(self.episode_lengths[ep_idx] // 4, 1),
             )
         tmp = start + length if length else self.episode_ends[ep_idx]
         end = min(tmp, self.episode_ends[ep_idx])

--- a/src/dataset/custom_dataset.py
+++ b/src/dataset/custom_dataset.py
@@ -347,7 +347,7 @@ class CustomDataset:
             current_conf_episode = 1
             while (
                 current_conf_episode < episodes_per_config
-                and current_episode < self.args["num_episodes"]
+                and current_episode <= self.args["num_episodes"]
             ):
                 for seed in range(seed_log["last_seed_tested"] + 1):
                     if (

--- a/src/dataset/custom_dataset.py
+++ b/src/dataset/custom_dataset.py
@@ -36,6 +36,7 @@ class CustomDataset:
         self.shard = None
         self.seed_finder = SeedFinder(self.args["num_episodes"])
         self.configs = self._get_configs()
+        self.category = self._get_category()
 
     def _get_configs(self):
         """
@@ -48,9 +49,9 @@ class CustomDataset:
             list: the configs.
         """
         configs = []
-        for config in LEVELS_CONFIGS[self.args["level"]]:
+        for config in LEVELS_CONFIGS["original_tasks"][self.args["level"]]:
             seed_log = self.seed_finder.load_seeds(self.args["level"], config)
-            if seed_log["num_train_seeds"]:
+            if seed_log["n_train_seeds"]:
                 configs.append(config)
         return configs
 
@@ -102,8 +103,52 @@ class CustomDataset:
         """
         metadata_path = os.getenv("ENV_METADATA_PATH", "env_metadata.jsonc")
         metadata = JsoncParser.parse_file(metadata_path)["levels"]
-        category = self._get_category()
-        return metadata[category][self.args["level"]]["used_action_space"]
+        return metadata[self.category][self.args["level"]]["used_action_space"]
+
+    def _get_level_max_steps(self):
+        """
+        Get the max steps for the environment.
+
+        Returns
+        -------
+        int: the max steps.
+        """
+        metadata_path = os.getenv("ENV_METADATA_PATH", "env_metadata.jsonc")
+        metadata = JsoncParser.parse_file(metadata_path)
+        level_metadata = metadata["levels"][self.category][self.args["level"]]
+
+        seq_instrs_factor = 4 if level_metadata["mission_space"]["sequence"] else 1
+        putnext_instrs_factor = 2 if level_metadata["putnext"] else 1
+        max_instrs_factor = 1 * seq_instrs_factor * putnext_instrs_factor
+
+        global_max_steps = 0
+        for config in self.configs:
+            try:
+                max_steps = level_metadata[config]["max_steps"]
+            except KeyError:
+                try:
+                    room_size = level_metadata[config]["room_size"]
+                except KeyError:
+                    room_size = metadata["defaults"]["room"]["room_size"]
+                try:
+                    num_rows = level_metadata[config]["num_rows"]
+                except KeyError:
+                    num_rows = (
+                        metadata["defaults"]["maze"]["num_rows"]
+                        if level_metadata["maze"]
+                        else 1
+                    )
+                try:
+                    num_cols = level_metadata[config]["num_cols"]
+                except KeyError:
+                    num_cols = (
+                        metadata["defaults"]["maze"]["num_cols"]
+                        if level_metadata["maze"]
+                        else 1
+                    )
+                max_steps = room_size**2 * num_rows * num_cols * max_instrs_factor
+            global_max_steps = max(global_max_steps, max_steps)
+        return global_max_steps
 
     def _policy(self, observation):
         """
@@ -170,26 +215,27 @@ class CustomDataset:
             return rule_feedback
 
     def _clear_buffer(self, obs_shape, config="", num_eps=EPS_PER_SHARD):
-        max_steps = self.env.max_steps
+        max_steps = self._get_level_max_steps()
         self.buffer = {
-            "configs": [config] * (max_steps * num_eps + 1),
-            "seeds": [[0]] * (max_steps * num_eps + 1),
-            "missions": [self.env.descr.surface(self.env)] * (max_steps * num_eps + 1),
+            "configs": [config] * ((max_steps + 1) * num_eps),
+            "seeds": np.array([[0]] * ((max_steps + 1) * num_eps)),
+            "missions": [self.env.instrs.surface(self.env)]
+            * ((max_steps + 1) * num_eps),
             "observations": np.array(
-                [np.zeros(obs_shape)] * (max_steps * num_eps + 1),
+                [np.zeros(obs_shape)] * ((max_steps + 1) * num_eps),
                 dtype=np.uint8,
             ),
             "actions": np.array(
-                [[0]] * (max_steps * num_eps + 1),
+                [[0]] * ((max_steps + 1) * num_eps),
                 dtype=np.float32,
             ),
             "rewards": np.array(
-                [[0]] * (max_steps * num_eps + 1),
+                [[0]] * ((max_steps + 1) * num_eps),
                 dtype=np.float32,
             ),
-            "feedback": [self._get_feedback_constant()] * (max_steps * num_eps + 1),
-            "terminations": np.array([[0]] * (max_steps * num_eps + 1), dtype=bool),
-            "truncations": np.array([[0]] * (max_steps * num_eps + 1), dtype=bool),
+            "feedback": [self._get_feedback_constant()] * ((max_steps + 1) * num_eps),
+            "terminations": np.array([[0]] * ((max_steps + 1) * num_eps), dtype=bool),
+            "truncations": np.array([[0]] * ((max_steps + 1) * num_eps), dtype=bool),
         }
         self.steps = 0
 
@@ -253,7 +299,7 @@ class CustomDataset:
         )
 
         md = MinariDataset(
-            level_group=self._get_category(self.args["level"]),
+            level_group=self.category,
             level_name=self.args["level"],
             dataset_name=name_dataset(self.args),
             policy=self.args["policy"],
@@ -291,14 +337,32 @@ class CustomDataset:
             shutil.rmtree(self.fp)
         os.makedirs(self.fp)
 
-        episodes_per_config = self.args["num_episodes"] // len(self.configs)
+        episodes_per_config = (self.args["num_episodes"] // len(self.configs)) + (
+            self.args["num_episodes"] % len(self.configs) > 0
+        )
 
-        ep_idx = 0
+        current_episode = 1
         for config in self.configs:
             seed_log = self.seed_finder.load_seeds(self.args["level"], config)
-
-            while ep_idx < episodes_per_config:
+            current_conf_episode = 1
+            while (
+                current_conf_episode < episodes_per_config
+                and current_episode < self.args["num_episodes"]
+            ):
                 for seed in range(seed_log["last_seed_tested"] + 1):
+                    if (
+                        current_conf_episode > episodes_per_config
+                        or seed > seed_log["last_seed_tested"]
+                        or current_episode > self.args["num_episodes"]
+                        # the second condition is here in case we want to use the same set of training seeds multiple times
+                        # e.g. if we want to create really big random dataset
+                        # and likely this will be necessary to train a PPO agent to convergence for harder levels
+                        # this should not result in duplicate trajectories despite the same seeds being used multiple times
+                        # when used with random policy, and even when used with the PPO agent as the agent will be at different
+                        # model checkpoints at the time the seeds get repeated
+                    ):
+                        break
+
                     if not self.seed_finder.is_test_seed(
                         seed_log, seed
                     ) and not self.seed_finder.is_validation_seed(seed_log, seed):
@@ -315,7 +379,7 @@ class CustomDataset:
                         self.state_dim = np.prod(obs.shape)
 
                         # initialise buffer to store replay data
-                        if ep_idx == 0:
+                        if current_episode == 1:
                             self._clear_buffer(obs.shape, config)
 
                         # feedback verifiers
@@ -329,26 +393,16 @@ class CustomDataset:
 
                         # create another episode
                         self._create_episode(config, seed)
-                        ep_idx = +1
 
                         # if buffer contains 1000 episodes or this is final episode, save data to file and clear buffer
-                        if ((ep_idx + 1) % EPS_PER_SHARD == 0) or ep_idx == self.args[
-                            "num_episodes"
-                        ] - 1:
+                        if (current_episode % EPS_PER_SHARD == 0) or (
+                            current_episode == self.args["num_episodes"]
+                        ):
                             self._save_buffer_to_minari_file()
                             self._clear_buffer(obs.shape, config)
 
-                        if (
-                            ep_idx == episodes_per_config
-                            or seed == seed_log["last_seed_tested"]
-                            # the second condition is here in case we want to use the same set of training seeds multiple times
-                            # e.g. if we want to create really big random dataset
-                            # and likely this will be necessary to train a PPO agent to convergence for harder levels
-                            # this should not result in duplicate trajectories despite the same seeds being used multiple times
-                            # when used with random policy, and even when used with the PPO agent as the agent will be at different
-                            # model checkpoints at the time the seeds get repeated
-                        ):
-                            break
+                        current_episode += 1
+                        current_conf_episode += 1
 
         self.env.close()
         self._clear_buffer(obs.shape)

--- a/src/dataset/custom_dataset.py
+++ b/src/dataset/custom_dataset.py
@@ -455,10 +455,11 @@ class CustomDataset:
         # optionally sample a random start timestep for this episode
         start = self.episode_starts[ep_idx]
         if random_start:
-            start += np.random.randint(0, self.episode_lengths[ep_idx])
+            start += np.random.randint(
+                0, self.episode_lengths[ep_idx] - self.episode_lengths[ep_idx] // 4
+            )
         tmp = start + length if length else self.episode_ends[ep_idx]
         end = min(tmp, self.episode_ends[ep_idx])
-
         s = self.shard.observations[start:end]
         s = normalise(s).reshape(1, -1, self.state_dim)
 

--- a/src/trainer/evaluator.py
+++ b/src/trainer/evaluator.py
@@ -19,7 +19,8 @@ import seaborn as sns
 
 from src.agent import Agent, AgentInput, RandomAgent
 from src.utils.utils import log, get_minigrid_obs, normalise
-from .atari_env import AtariEnv
+
+# from .atari_env import AtariEnv
 from .visualiser import Visualiser, AtariVisualiser
 
 sns.set_theme()
@@ -45,10 +46,16 @@ class Evaluator(TrainerCallback):
         self.best_lengths = {"random": 0, "DT": 0}
         self.num_repeats = num_repeats
         self.gamma = gamma
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.device = torch.device(
+            "cuda"
+            if torch.cuda.is_available()
+            else ("mps" if torch.backends.mps.is_available() else "cpu")
+        )
 
         # create the output directory if it doesn't exist
-        self.output_dir = os.path.join(self.user_args["output"], self.user_args["run_name"])
+        self.output_dir = os.path.join(
+            self.user_args["output"], self.user_args["run_name"]
+        )
         if not os.path.exists(self.output_dir):
             os.makedirs(self.output_dir)
 
@@ -71,10 +78,14 @@ class Evaluator(TrainerCallback):
         #     np.array(["No mission available."] * user_args["context_length"])
         # ).to(self.device)
         self.feedback_embeddings = (
-            torch.from_numpy(np.random.rand(1, 64, 128)).to(self.device).float()
+            torch.from_numpy(np.random.rand(1, self.user_args["context_length"], 128))
+            .float()
+            .to(self.device)
         )
         self.mission_embeddings = (
-            torch.from_numpy(np.random.rand(1, 64, 128)).to(self.device).float()
+            torch.from_numpy(np.random.rand(1, self.user_args["context_length"], 128))
+            .float()
+            .to(self.device)
         )
 
         # create a random agent to evaluate against
@@ -120,19 +131,19 @@ class Evaluator(TrainerCallback):
         self._plot_results()
 
     def _create_env(self, atari=False):
-        env_name = self.user_args["env_name"]
-        if atari:
-            game = env_name.split(":")[1]
-            _env = AtariEnv(self.device, game, self.user_args["seed"])
-            return AtariVisualiser(
-                _env,
-                self.output_dir,
-                filename=f"tmp",
-                seed=self.user_args["seed"],
-            )
+        env_name = self.user_args["level"]
+        # if atari:
+        #     game = env_name.split(":")[1]
+        #     _env = AtariEnv(self.device, game, self.user_args["seed"])
+        #     return AtariVisualiser(
+        #         _env,
+        #         self.output_dir,
+        #         filename=f"tmp",
+        #         seed=self.user_args["seed"],
+        #     )
 
-        _env = gym.make(self.user_args["env_name"], render_mode="rgb_array")
-        return Visualiser(_env, self.output_dir, filename=f"tmp", seed=self.user_args["seed"])
+        _env = gym.make("BabyAI-GoToRedBallGrey-v0", render_mode="rgb_array")
+        return Visualiser(_env, self.output_dir, filename=f"tmp", seed=0)
 
     def _record_return(self, env, ret, ep_length, model_name):
         self.results["samples"].append(self.collator.samples_processed)
@@ -159,9 +170,11 @@ class Evaluator(TrainerCallback):
                 env.save_as(f"longest_{model_name}")
 
     def _evaluate_agent_performance(self, agent: Agent, agent_name: str):
-        atari = self.user_args["env_name"].startswith("atari")
-        run_agent = self._run_agent_on_atari_env if atari else self._run_agent_on_minigrid_env
-
+        atari = self.user_args["level"].startswith("atari")
+        # run_agent = (
+        #     self._run_agent_on_atari_env if atari else self._run_agent_on_minigrid_env
+        # )
+        run_agent = self._run_agent_on_minigrid_env
         # for each repeat, record the episode return (and optionally render a video of the episode)
         for _ in range(self.num_repeats):
             env = self._create_env(atari=atari)
@@ -184,7 +197,9 @@ class Evaluator(TrainerCallback):
         accs = np.zeros(repeats)
 
         for rep in range(repeats):
-            batch = self.collator._sample_batch(1, random_start=True, full=True, train=False)
+            batch = self.collator._sample_batch(
+                1, random_start=True, full=True, train=False
+            )
             for k in batch:
                 batch[k] = batch[k].to(self.device)
 
@@ -215,7 +230,9 @@ class Evaluator(TrainerCallback):
             with_tqdm=True,
         )
 
-    def _run_agent_on_minigrid_env(self, agent: Agent, env: Visualiser, target_return: float):
+    def _run_agent_on_minigrid_env(
+        self, agent: Agent, env: Visualiser, target_return: float
+    ):
         def get_state(partial_obs):
             obs = get_minigrid_obs(
                 env.get_env(),
@@ -289,100 +306,104 @@ class Evaluator(TrainerCallback):
         # return discounted_cumsum(rewards.detach().cpu().numpy(), self.gamma)[0], t
         return np.sum(rewards.detach().cpu().numpy()), t
 
-    def _run_agent_on_atari_env(
-        self, agent: Agent, env: AtariVisualiser, target_return: float, stack_size=4
-    ):
-        def get_state(frames):
-            frames = frames.permute(1, 2, 0)
-            return normalise(frames.reshape(1, self.collator.state_dim)).to(
-                device=self.device, dtype=torch.float32
-            )
+    # def _run_agent_on_atari_env(
+    #     self, agent: Agent, env: AtariVisualiser, target_return: float, stack_size=4
+    # ):
+    #     def get_state(frames):
+    #         frames = frames.permute(1, 2, 0)
+    #         return normalise(frames.reshape(1, self.collator.state_dim)).to(
+    #             device=self.device, dtype=torch.float32
+    #         )
 
-        max_ep_len = env.max_steps if hasattr(env, "max_steps") else 5000
+    #     max_ep_len = env.max_steps if hasattr(env, "max_steps") else 5000
 
-        obs = env.reset(seed=self.user_args["seed"])
-        init_s = get_state(obs).detach().cpu().numpy()
+    #     obs = env.reset(seed=self.user_args["seed"])
+    #     init_s = get_state(obs).detach().cpu().numpy()
 
-        _start_idx = 655
-        NUM_INITIAL_ACTIONS = 10
+    #     _start_idx = 655
+    #     NUM_INITIAL_ACTIONS = 10
 
-        # ref_states = normalise(self.collator.observations[_start_idx : _start_idx + NUM_INITIAL_ACTIONS])
+    #     # ref_states = normalise(self.collator.observations[_start_idx : _start_idx + NUM_INITIAL_ACTIONS])
 
-        # states = get_state(obs)
-        states = torch.zeros(0, device=self.device, dtype=torch.float32)
-        actions = torch.tensor(
-            self.collator.actions[_start_idx : _start_idx + NUM_INITIAL_ACTIONS],
-            device=self.device,
-        )
-        rewards = torch.zeros(0, device=self.device, dtype=torch.float32)
-        returns_to_go = torch.zeros(0, device=self.device, dtype=torch.float32)
-        timesteps = torch.zeros(0, device=self.device, dtype=torch.long)
+    #     # states = get_state(obs)
+    #     states = torch.zeros(0, device=self.device, dtype=torch.float32)
+    #     actions = torch.tensor(
+    #         self.collator.actions[_start_idx : _start_idx + NUM_INITIAL_ACTIONS],
+    #         device=self.device,
+    #     )
+    #     rewards = torch.zeros(0, device=self.device, dtype=torch.float32)
+    #     returns_to_go = torch.zeros(0, device=self.device, dtype=torch.float32)
+    #     timesteps = torch.zeros(0, device=self.device, dtype=torch.long)
 
-        # execute set of initial actions to get going
-        a_idxs = []
-        for i, a in enumerate(actions):
-            a_idx = np.argmax(a.detach().cpu().numpy())
-            a_idxs.append(a_idx)
+    #     # execute set of initial actions to get going
+    #     a_idxs = []
+    #     for i, a in enumerate(actions):
+    #         a_idx = np.argmax(a.detach().cpu().numpy())
+    #         a_idxs.append(a_idx)
 
-            obs, r, _ = env.step(a_idx)
-            s = get_state(obs)
+    #         obs, r, _ = env.step(a_idx)
+    #         s = get_state(obs)
 
-            states = torch.cat([states, s], dim=0)
-            rewards = torch.cat([rewards, torch.tensor(r, device=self.device).reshape(1)])
+    #         states = torch.cat([states, s], dim=0)
+    #         rewards = torch.cat(
+    #             [rewards, torch.tensor(r, device=self.device).reshape(1)]
+    #         )
 
-            if i == 0:
-                returns_to_go = torch.tensor(
-                    target_return, device=self.device, dtype=torch.float32
-                ).reshape(1, 1)
-            else:
-                returns_to_go = torch.cat(
-                    [returns_to_go, (returns_to_go[0, -1] - r).reshape(1, 1)], dim=1
-                )
+    #         if i == 0:
+    #             returns_to_go = torch.tensor(
+    #                 target_return, device=self.device, dtype=torch.float32
+    #             ).reshape(1, 1)
+    #         else:
+    #             returns_to_go = torch.cat(
+    #                 [returns_to_go, (returns_to_go[0, -1] - r).reshape(1, 1)], dim=1
+    #             )
 
-        for t in range(NUM_INITIAL_ACTIONS, max_ep_len):
-            # get action from agent
-            a = agent.get_action(
-                AgentInput(
-                    mission_embeddings=self.mission_embeddings,
-                    states=states,
-                    actions=actions,
-                    rewards=rewards,
-                    returns_to_go=returns_to_go,
-                    timesteps=timesteps,
-                    feedback_embeddings=self.feedback_embeddings,
-                    attention_mask=None,
-                ),
-                context=self.user_args["context_length"],
-                one_hot=True,
-            )
+    #     for t in range(NUM_INITIAL_ACTIONS, max_ep_len):
+    #         # get action from agent
+    #         a = agent.get_action(
+    #             AgentInput(
+    #                 mission_embeddings=self.mission_embeddings,
+    #                 states=states,
+    #                 actions=actions,
+    #                 rewards=rewards,
+    #                 returns_to_go=returns_to_go,
+    #                 timesteps=timesteps,
+    #                 feedback_embeddings=self.feedback_embeddings,
+    #                 attention_mask=None,
+    #             ),
+    #             context=self.user_args["context_length"],
+    #             one_hot=True,
+    #         )
 
-            # take action, get next state and reward
-            a_idx = np.argmax(a.detach().cpu().numpy())
-            a_idxs.append(a_idx)
-            obs, r, done = env.step(a_idx)
-            s = get_state(obs)
+    #         # take action, get next state and reward
+    #         a_idx = np.argmax(a.detach().cpu().numpy())
+    #         a_idxs.append(a_idx)
+    #         obs, r, done = env.step(a_idx)
+    #         s = get_state(obs)
 
-            # update state, reward, return, timestep tensors
-            states = torch.cat([states, s], dim=0)
-            actions = torch.cat([actions, a.reshape((1, 4))], dim=0)
-            rewards = torch.cat([rewards, torch.tensor(r, device=self.device).reshape(1)])
-            returns_to_go = torch.cat(
-                [returns_to_go, (returns_to_go[0, -1] - r).reshape(1, 1)], dim=1
-            )
+    #         # update state, reward, return, timestep tensors
+    #         states = torch.cat([states, s], dim=0)
+    #         actions = torch.cat([actions, a.reshape((1, 4))], dim=0)
+    #         rewards = torch.cat(
+    #             [rewards, torch.tensor(r, device=self.device).reshape(1)]
+    #         )
+    #         returns_to_go = torch.cat(
+    #             [returns_to_go, (returns_to_go[0, -1] - r).reshape(1, 1)], dim=1
+    #         )
 
-            timesteps = torch.cat(
-                [
-                    timesteps,
-                    torch.ones((1, 1), device=self.device, dtype=torch.long) * t,
-                ],
-                dim=1,
-            )
+    #         timesteps = torch.cat(
+    #             [
+    #                 timesteps,
+    #                 torch.ones((1, 1), device=self.device, dtype=torch.long) * t,
+    #             ],
+    #             dim=1,
+    #         )
 
-            if done:
-                break
+    #         if done:
+    #             break
 
-        # return discounted_cumsum(rewards.detach().cpu().numpy(), self.gamma)[0], t
-        return np.sum(rewards.detach().cpu().numpy()), t
+    #     # return discounted_cumsum(rewards.detach().cpu().numpy(), self.gamma)[0], t
+    #     return np.sum(rewards.detach().cpu().numpy()), t
 
     def _plot_loss(self, state: TrainerState):
         fig, ax = plt.subplots()

--- a/src/trainer/trainer.py
+++ b/src/trainer/trainer.py
@@ -22,7 +22,9 @@ class AgentTrainer(Trainer):
             args=TrainingArguments(
                 run_name=self.user_args["run_name"],
                 output_dir=self.user_args["output"],
-                report_to="none" if self.user_args["wandb_mode"] == "disabled" else "wandb",
+                report_to="none"
+                if self.user_args["wandb_mode"] == "disabled"
+                else "wandb",
                 logging_steps=self.user_args["log_interval"],
                 remove_unused_columns=False,
                 num_train_epochs=self.user_args["epochs"],
@@ -41,7 +43,9 @@ class AgentTrainer(Trainer):
         self.create_callbacks()
 
     def create_callbacks(self):
-        self.add_callback(Evaluator(user_args=self.user_args, collator=self.data_collator))
+        self.add_callback(
+            Evaluator(user_args=self.user_args, collator=self.data_collator)
+        )
 
     def compute_loss(self, model, inputs, return_outputs=False):
         input = AgentInput(**inputs)

--- a/src/utils/argparsing.py
+++ b/src/utils/argparsing.py
@@ -11,12 +11,6 @@ def get_args():
         help="name of the run (default: current date and time)",
     )
     parser.add_argument(
-        "--env_name",
-        type=str,
-        default="BabyAI-GoToRedBallGrey-v0",
-        help="the name of the environment config; must be registered with gymnasium",
-    )
-    parser.add_argument(
         "--num_episodes",
         type=int,
         default=100,
@@ -32,12 +26,6 @@ def get_args():
         type=bool,
         default=True,
         help="whether to include episodes terminated by timeout / truncated",
-    )
-    parser.add_argument(
-        "--load_dataset_if_exists",
-        type=bool,
-        default=True,
-        help="whether to load the dataset from local storage if it already exists",
     )
     parser.add_argument(
         "--fully_obs",
@@ -166,5 +154,11 @@ def get_args():
         type=str,
         default="GoToRedBallGrey",
         help="the name of the level to train on.",
+    )
+    parser.add_argument(
+        "--train_mode",
+        type=str,
+        default="single_task",
+        help="the training mode to use; can be either 'single_task', 'round_robin', 'curriculum' or 'anti_curriculum.",
     )
     return vars(parser.parse_args())

--- a/src/utils/argparsing.py
+++ b/src/utils/argparsing.py
@@ -54,7 +54,7 @@ def get_args():
     parser.add_argument(
         "--context_length",
         type=int,
-        default=64,
+        default=16,
         help="context length in timesteps (default: 64)",
     )
     parser.add_argument("--randomise_starts", type=bool, default=False)

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -43,7 +43,9 @@ def setup_devices(seed, useGpu=True):
     torch.manual_seed(seed)
 
     if useCuda:
-        device_str = f"{device.type}:{device.index}" if device.index else f"{device.type}"
+        device_str = (
+            f"{device.type}:{device.index}" if device.index else f"{device.type}"
+        )
         os.environ["CUDA_VISIBLE_DEVICES"] = device_str
         torch.cuda.manual_seed_all(seed)
         torch.backends.cudnn.deterministic = True


### PR DESCRIPTION
**A couple of fixes of things I missed when I first updated the dataset generation code to account for multiple seeds and configs, the gist of which is:**
-we can now create mixed-config shards
-when the number of episodes that needs to be created cannot be split evenly among the available configs, we round up the number of episodes per config, which means we don't stop before reaching the full number of episodes but rather the last config is under-sampled
-the max steps are now determined dynamically based on the largest environment configuration amongst all available configs for a given level (and a factor for the most difficult possible instructions for the level) - this follows the same logic as is used in BabyAI to determine the max steps for an env, as we may end up with different max steps for different seeds and configs for the same level, all stored in the same buffer
-when sampling episode indexes, we now cover the edge case where random sampling of a starting point results in the start index equalling the end index (resulting in empty arrays)
-a couple of random bug fixes

**A couple of updates elsewhere**:
-any references to args["env_name"] replaced with args["level"]
-any device selection logic now includes MPS (for running locally on Macs)
-casting tensors in float32 to be compatible with MPS devices (again for running locally on Macs - haven't tested this with cuda on the cluster yet, hopefully it'll be fine)
-hard coded context length in string embeddings replaced with the context length provided via the args
-default value for the context length argument set to 16 (mostly as it results in shorter sequences for now and makes debugging faster, but it might actually turn out to be fine)
-commented out some Atari specific code for now as I'm struggling to install the library and it keeps me from running code I need to run