### PR TITLE
Implement pre-commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+    -   id: check-added-large-files
+        args: ['--maxkb=500']
+    -   id: check-merge-conflict
+    -   id: check-json
+    -   id: no-commit-to-branch
+        args: ['--branch', 'master']
+-   repo: https://github.com/asottile/reorder-python-imports
+    rev: v3.10.0
+    hooks:
+    -   id: reorder-python-imports

--- a/Pipfile
+++ b/Pipfile
@@ -33,6 +33,7 @@ torch = "*"
 torchvision = "*"
 torchaudio = "*"
 torch-ac = "*"
+pre-commit = "*"
 
 [dev-packages]
 ipykernel = "*"


### PR DESCRIPTION
I've implemented pre-commit, maybe a good idea for you to install this too? If you're using Black we can also add a hook for formatting.

https://pre-commit.com/index.html

Currently, pre-commit checks include (see the pre-commit-config.yaml):
end-of-file-fixer
trailing-whitespace
check-added-large-files (for maxkb=500)
check-merge-conflict
check-json
no-commit-to-branch (for master)
reorder-python-imports

This obvs only applies to commits, but we can maybe run this globally for existing files at some point when we're both between PR's?