### PR TITLE
Disable wandb + small fixes

### DIFF
--- a/scripts/experiments/preliminary/gen_experiment.py
+++ b/scripts/experiments/preliminary/gen_experiment.py
@@ -47,7 +47,7 @@ for c in combinations:
     for i, var in enumerate(variables.keys()):
         expt_call += f" --{var} {c[i]}"
 
-    expt_call += f"--run_name {run_name(c, variables.keys())}"
+    expt_call += f" --run_name {run_name(c, variables.keys())}"
     print(expt_call, file=output_file)
 
 output_file.close()

--- a/scripts/train_agent_babyai.py
+++ b/scripts/train_agent_babyai.py
@@ -26,12 +26,14 @@ args = get_args()
 args["output"] = OUTPUT_PATH
 frame_size = 64 if args["fully_obs"] else 56
 
+args["wandb_mode"] = "disabled"
+args["report_to"] = "none"
 log("setting up devices")
 if torch.cuda.is_available():
     device = torch.device("cuda")
     device_str = f"{device.type}:{device.index}" if device.index else f"{device.type}"
     os.environ["CUDA_VISIBLE_DEVICES"] = device_str
-    log(f"Using device: {torch.cuda.get_device_name()}")
+    # log(f"Using device: {torch.cuda.get_device_name()}")
     log("using gpu")
 elif not torch.backends.mps.is_available():
     if not torch.backends.mps.is_built():

--- a/src/utils/argparsing.py
+++ b/src/utils/argparsing.py
@@ -89,7 +89,7 @@ def get_args():
     parser.add_argument(
         "--wandb_mode",
         type=str,
-        default="offline",
+        default="disabled",
         help="wandb mode - can be online, offline, or disabled",
     )
     parser.add_argument(


### PR DESCRIPTION
mini PR to disable weights and biases for now. also fixes typo in gen_experiment.py, and comments out a log line bc `torch.cuda.get_device_name()` seems to throw an error sometimes even though the GPU is fine