### PR TITLE
Small fixes to experiment setup

### DIFF
--- a/scripts/experiments/mlp_cluster_max/job.sh
+++ b/scripts/experiments/mlp_cluster_max/job.sh
@@ -56,7 +56,7 @@
 # Any nodes to exclude from selection
 # #SBATCH --exclude=charles[05,12-18]
 
-#BATCH --mem-per-cpu=64G
+#SBATCH --mem-per-cpu=64G
 
 # =====================
 # Logging information

--- a/scripts/experiments/mlp_cluster_sab/job.sh
+++ b/scripts/experiments/mlp_cluster_sab/job.sh
@@ -56,7 +56,7 @@
 # Any nodes to exclude from selection
 # #SBATCH --exclude=charles[05,12-18]
 
-#BATCH --mem-per-cpu=64G
+#SBATCH --mem-per-cpu=64G
 
 # =====================
 # Logging information

--- a/src/env/feedback_env.py
+++ b/src/env/feedback_env.py
@@ -103,7 +103,7 @@ class FeedbackEnv:
         return self.env.get_frame(*args, **kwargs)
 
     def get_mission(self):
-        return self.env.instrs.surface(self)
+        return self.env.instrs.surface(self.env)
 
     def room_from_pos(self, *args, **kwargs):
         return self.env.room_from_pos(*args, **kwargs)


### PR DESCRIPTION
Note that we still need to add the node exclusion list to the job.sh files - I didn't push this as it's likely to vary based on when you're starting the envs, but follow these steps:
**Check how busy the different nodes are**
 sinfo -p PGR-Standard -N -O "NodeHost","CPUsState","FreeMem"
-> identify nodes that fit the requirements (remember we need at least 64G per CPU -> 128G in total so damnii nodes with jobs running on them already are a bit risky and should be avoided
**Specify the node exclusion list**
Example below - the command already exists and just needs to be uncommented/the list of nodes updated (I believe we can specify a range in the format crannog[01-02] but haven't tried that yet)
# Any nodes to exclude from selection
#SBATCH --exclude=crannog01,damnii05,damnii05,damnii06,damnii07,damnii09,damnii10,damnii11