### PR TITLE
Various fixes based on random data experiments

### DIFF
--- a/scripts/train_agent_babyai.py
+++ b/scripts/train_agent_babyai.py
@@ -77,6 +77,8 @@ else:
     log("Creating standard single-task collator...")
     collator = Collator(
         custom_dataset=dataset,
+        full=args["use_full_ep"],
+        episode_dist=args["ep_dist"],
         args=args,
     )
 

--- a/scripts/train_agent_babyai_local_tests.py
+++ b/scripts/train_agent_babyai_local_tests.py
@@ -27,12 +27,14 @@ args = get_args()
 
 args["output"] = OUTPUT_PATH
 args["run_name"] = f"{date.today()}_test"
-args["level"] = "PutNextLocal"
-args["num_steps"] = 12800
+args["level"] = "GoToObj"
+args["num_steps"] = 10000
 args["wandb_mode"] = "disabled"
 args["report_to"] = "none"
 args["epochs"] = 1
 args["log_interval"] = 1
+args["policy"] = "random"
+args["context_length"] = 8
 
 
 frame_size = 64 if args["fully_obs"] else 56

--- a/src/dataset/custom_dataset.py
+++ b/src/dataset/custom_dataset.py
@@ -579,7 +579,7 @@ class CustomDataset:
         return self
 
     def __len__(self):
-        return self.num_shards * self.eps_per_shard
+        return self.args["num_steps"] / self.args["context_length"]
 
     # ----- these methods aren't used, but need to be defined for torch dataloaders to work -----
 

--- a/src/env/feedback_env.py
+++ b/src/env/feedback_env.py
@@ -79,8 +79,14 @@ class FeedbackEnv:
 
         # check if max steps reached
         self.steps_taken += 1
-        if self.max_steps is not None and self.steps_taken >= self.max_steps:
+        if (
+            self.max_steps is not None
+            and self.steps_taken >= self.max_steps
+            and not terminated
+        ):
             truncated = True
+        else:
+            truncated = False
 
         # get task feedback (after taking action)
         task_feedback = self.task_feedback(action)

--- a/src/ppo/ppo_agent.py
+++ b/src/ppo/ppo_agent.py
@@ -57,7 +57,7 @@ class PPOAgent:
             if env_name in ["BabyAI-OpenTwoDoors-v0", "BabyAI-OpenRedBlueDoors-v0"]
             else 1,
             "text": True,
-            "argmax": True,
+            "argmax": False,
             "feedback_mode": feedback_mode,
             "max_steps": max_steps,
         }

--- a/src/utils/argparsing.py
+++ b/src/utils/argparsing.py
@@ -165,8 +165,8 @@ def get_args():
     parser.add_argument(
         "--sample_interval",
         type=int,
-        default=20000,
-        help="whether to use the pretrained GPT-2 model",
+        default=1280,
+        help="after how many samples to evaluate the sample efficiency of the model",
     )
     parser.add_argument(
         "--target_return",
@@ -203,5 +203,23 @@ def get_args():
         type=int,
         default=10,
         help="the number of episodes to collect per dataset shard",
+    )
+    parser.add_argument(
+        "--use_full_ep",
+        type=bool,
+        default=False,
+        help="whether to use the full episode, rather than a given context length",
+    )
+    parser.add_argument(
+        "--ep_dist",
+        type=str,
+        default="inverse_length",
+        help="the distribution from which to sample episodes",
+    )
+    parser.add_argument(
+        "--num_samples",
+        type=int,
+        default=10000,
+        help="the number of samples - sub-episodes or full episodes - to train on. If 0, will use all available samples",
     )
     return vars(parser.parse_args())


### PR DESCRIPTION
-account for cases where the agent is successful at the last time step
-some adjustments to the existing logic that allows for training with full episodes
-including last episode step for RTG calculation
-evaluating sample efficiency on training seeds during training, IID generalisation (val seeds) and OOD generalisation (test seeds) at the end of training
-using dataset `len` attribute to set number of training samples (1 sample = 1 sub-episode / 1 action prediction), and setting this to be either the number of episodes in the dataset or specifying a (smaller) number of samples

